### PR TITLE
Let multi_xml decide the best parser

### DIFF
--- a/lib/rundeck/request.rb
+++ b/lib/rundeck/request.rb
@@ -1,5 +1,5 @@
 require 'httparty'
-require 'libxml'
+require 'multi_xml'
 
 module Rundeck
   # @private

--- a/rundeck.gemspec
+++ b/rundeck.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_runtime_dependency 'httparty'
-  spec.add_runtime_dependency 'libxml-ruby'
+  spec.add_runtime_dependency 'multi_xml'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Letting multi_xml decide to use the best available parser makes installation in a custom ruby environment (i.e.: Chef) easier.